### PR TITLE
Add URL identification for boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# ProgPoW - Rust
+
+ProgPoW is a proof-of-work algorithm designed to close the efficiency gap available to specialized ASICs. It utilizes almost all parts of commodity hardware (GPUs), and comes pre-tuned for the most common hardware.
+
+This is a rust build of the current C++ algorithm.
+
+## Build steps
+
+To build the project you will have to specify if the application is `only CPU`, `OPENCL`, or `CUDA`.
+To build for an application using **CPU**, execute the following line in the terminal:
+
+```sh
+cargo build
+```
+
+To build for an application using **CPUs/GPUs** use `OPENCL`. Execute the following line in the terminal to build with `OPENCL`:
+
+```sh
+cargo build --features opencl
+```
+
+If you have NVIDIA GPUs and your system has **the latest Nvidia drivers and the Cuda toolkit 9+ installed**, you can build the Cuda plugins using the following command:
+
+```sh
+cargo build --no-default-features --features cuda
+```
+
+## What was built
+
+The rust library of the ProgPoW algorithm

--- a/pp_full/lib/CMakeLists.txt
+++ b/pp_full/lib/CMakeLists.txt
@@ -21,9 +21,9 @@ cable_configure_toolchain(DEFAULT cxx11)
 
 set(HUNTER_CONFIGURATION_TYPES Release)
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.20.34.tar.gz"
-    SHA1 "2f04d1beffdf39db1c40d8347beb8c10bbe9b8ed"
-    LOCAL
+    URL "https://github.com/ruslo/hunter/archive/v0.23.214.tar.gz"
+    SHA1 "e14bc153a7f16d6a5eeec845fb0283c8fad8c358"
+	LOCAL
 )
 
 project(progpow)

--- a/pp_full/lib/cmake/Hunter/config.cmake
+++ b/pp_full/lib/cmake/Hunter/config.cmake
@@ -1,2 +1,8 @@
-hunter_config(CURL VERSION ${HUNTER_CURL_VERSION} CMAKE_ARGS HTTP_ONLY=ON CMAKE_USE_OPENSSL=OFF CMAKE_USE_LIBSSH2=OFF)
+hunter_config(CURL VERSION ${HUNTER_CURL_VERSION} CMAKE_ARGS HTTP_ONLY=ON CMAKE_USE_OPENSSL=OFF CMAKE_USE_LIBSSH2=OFF CURL_CA_PATH=none)
 hunter_config(libjson-rpc-cpp VERSION ${HUNTER_libjson-rpc-cpp_VERSION} CMAKE_ARGS TCP_SOCKET_SERVER=ON)
+hunter_config(
+    Boost
+    VERSION 1.66.0_new_url
+    SHA1 f0b20d2d9f64041e8e7450600de0267244649766
+    URL https://boostorg.jfrog.io/artifactory/main/release/1.66.0/source/boost_1_66_0.tar.gz
+)


### PR DESCRIPTION
# Context

The ProgPoW is currently failing to build due to a misidentification of the Boost library on Cmake.
To add the URL and SHA1 identification, the version of Hunter was also updated

## Changes

- Add URL and SHA1 identification to make boost
- Bump the version of hunter to 0.23.214