### PR TITLE
Upgrade boost to allow macOS GPU build

### DIFF
--- a/pp_full/lib/cmake/Hunter/config.cmake
+++ b/pp_full/lib/cmake/Hunter/config.cmake
@@ -2,7 +2,7 @@ hunter_config(CURL VERSION ${HUNTER_CURL_VERSION} CMAKE_ARGS HTTP_ONLY=ON CMAKE_
 hunter_config(libjson-rpc-cpp VERSION ${HUNTER_libjson-rpc-cpp_VERSION} CMAKE_ARGS TCP_SOCKET_SERVER=ON)
 hunter_config(
     Boost
-    VERSION 1.66.0_new_url
-    SHA1 f0b20d2d9f64041e8e7450600de0267244649766
-    URL https://boostorg.jfrog.io/artifactory/main/release/1.66.0/source/boost_1_66_0.tar.gz
+    VERSION 1.80.0_new_url
+    SHA1 4ff012adaa7d8952913be05bf4233005de48289c
+    URL https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz
 )


### PR DESCRIPTION
# Description

Update the current version of Boost from 1.66.0 to 1.80.0 to allow macOS opencl build.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes

- [x] Tested on macOS
- [x] Tested on Ubuntu

# Relevant notes

Issue reported on:
- https://github.com/arvidn/libtorrent/issues/4662